### PR TITLE
Add dry run mode to sync

### DIFF
--- a/docs/examples/sqlserver-to-itop.md
+++ b/docs/examples/sqlserver-to-itop.md
@@ -149,11 +149,11 @@ sync:
       - transformer: itop.relations
         config:
           field_relations: 
-            source_field: parent_id
-            source_comparison_field: parent_code
-            foreign_class_type: Organization
-            foreign_comparison_field: code
-            use_like_operator: false
+            - source_field: parent_id
+              source_comparison_field: parent_code
+              foreign_class_type: Organization
+              foreign_comparison_field: code
+              use_like_operator: false
 
 ```
 **links**:

--- a/docs/getting-started/change-notes.md
+++ b/docs/getting-started/change-notes.md
@@ -23,6 +23,7 @@
   - This [changelog](/getting-started/change-notes.html).
   - A [flowchart](/getting-started/change-notes.html) explaining the beetl sync process.
   - And a lot of other additions from data sources to transformers and examples.
+- A dry run mode has been added. If you pass `dry_run=True` to `beetl.sync()` no mutations will be done on the operation and the sync method will return a list containing one ComparisonResult per sync in the configuration containing the create, update and delete DataFrames post instertion and deletion transformers.
 
 
 ### Bugfixes 🐛

--- a/src/beetl/__version__.py
+++ b/src/beetl/__version__.py
@@ -2,7 +2,7 @@
 
 import os
 
-FALLBACK_VERSION = "1.0.0-rc.1"
+FALLBACK_VERSION = "1.0.0-rc.2"
 
 __title__ = "beetl"
 __description__ = """

--- a/src/beetl/comparison_result.py
+++ b/src/beetl/comparison_result.py
@@ -1,0 +1,12 @@
+from polars import DataFrame
+
+
+class ComparisonResult:
+    create: DataFrame
+    update: DataFrame
+    delete: DataFrame
+
+    def __init__(self, create: DataFrame, update: DataFrame, delete: DataFrame):
+        self.create = create
+        self.update = update
+        self.delete = delete

--- a/tests/functionality_testing/beetl/test_beetl.py
+++ b/tests/functionality_testing/beetl/test_beetl.py
@@ -4,6 +4,7 @@ import yaml
 import unittest
 from copy import deepcopy
 from polars import DataFrame
+from src.beetl.comparison_result import ComparisonResult
 from src.beetl import beetl, config
 from src.beetl.sources import interface as src_if
 from tests.configurations.static import to_static
@@ -103,3 +104,14 @@ class TestBeetlFunctions(unittest.TestCase):
             delete.to_dict(as_series=False),
             {"id": [4], "name": ["James"], "email": ["jane@test.com"]},
         )
+
+    def test_dry_run_sync(self):
+
+        beetl_config = beetl.BeetlConfig(to_static())
+        beetl_instance = beetl.Beetl(beetl_config)
+        comparison_results = beetl_instance.sync(dry_run=True)
+
+        self.assertTrue(len(comparison_results) > 0)
+        result = comparison_results[0]
+
+        self.assertTrue(isinstance(result, ComparisonResult))


### PR DESCRIPTION
Adding a dry run mode to the sync method allowing integration developers to test without performing any mutations on the destination.