### PR TITLE
26 pipeline is using deprecated setuptools commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
 				"ms-python.python",
 				"ms-python.debugpy",
 				"ms-python.autopep8",
-				"github.vscode-github-actions"
+				"github.vscode-github-actions",
+				"tamasfe.even-better-toml"
 			]
 		}
 	}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,4 +6,5 @@ mkdir /tmp/beetl \
     && sudo apt-get update \
     && sudo ACCEPT_EULA=Y apt-get -y install libmariadb-dev libpq-dev unixodbc unixodbc-dev python3-venv msodbcsql18 libgssapi-krb5-2 \
     && sudo apt-get clean \
-    && pip3 install --user -r requirements.txt
+    && python -m pip install --user -r requirements.txt \
+    && python -m pip install wheel build setuptools twine

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,4 +7,4 @@ mkdir /tmp/beetl \
     && sudo ACCEPT_EULA=Y apt-get -y install libmariadb-dev libpq-dev unixodbc unixodbc-dev python3-venv msodbcsql18 libgssapi-krb5-2 \
     && sudo apt-get clean \
     && python -m pip install --user -r requirements.txt \
-    && python -m pip install wheel build setuptools twine
+    && python -m pip install build twine

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install setuptools wheel twine
+        python -m pip install setuptools wheel twine build
         
     - name: Build
       env:
@@ -31,7 +31,7 @@ jobs:
         GHBRANCH: ${{ github.ref }}
         GHTAG: ${{ github.ref_name }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
 
     - name: Publish to pypi
       if: github.event_name != 'pull_request'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip .
         pip install -r requirements.txt
         pip install setuptools wheel twine
         
@@ -29,16 +29,13 @@ jobs:
       env:
         GHRUN: ${{ github.run_id }}
         GHBRANCH: ${{ github.ref }}
-        GHRELEASE: ${{ github.event.release.tag_name }}
+        GHTAG: ${{ github.ref_name }}
       run: |
         python setup.py sdist bdist_wheel
 
     - name: Publish to pypi
       if: github.event_name != 'pull_request'
       env:
-        GHRUN: ${{ github.run_id }}
-        GHBRANCH: ${{ github.ref }}
-        GHRELEASE: ${{ github.event.release.tag_name }}
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,21 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Install dependencies
+    - name: Upgrade pip
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install setuptools wheel twine build
+        python -m pip install build twine
+
+    - name: Install install project dependencies
+      run: |
+        python -m pip install -r requirements.txt
+
+    - name: Install packaging dependencies
+      run: |
+        python -m pip install build twine
         
-    - name: Build
+    - name: Build and package project
       env:
         GHRUN: ${{ github.run_id }}
         GHBRANCH: ${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip .
-        pip install -r requirements.txt
-        pip install setuptools wheel twine
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+        python -m pip install setuptools wheel twine
         
     - name: Build
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,23 @@ classifiers = [
 dynamic = ["version", "readme"]
 urls = { "github" = "https://github.com/Hoglandets-IT/beetl" }
 requires-python = ">=3.8"
+dependencies = [
+  "requests",
+  "polars[all]>=1.14.0",
+  "sqlalchemy",
+  "pandas>=2.2.3",
+  "psycopg",
+  "psycopg2",
+  "pyyaml",
+  "pymysql",
+  "pyodbc",
+  "pymssql",
+  "mysql-connector-python",
+  "alive-progress",
+  "tabulate",
+  "pymongo>=4.10.1",
+  "cryptography",
+]
+
+[tool.setuptools]
+package-dir = { "" = "src" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "beetl"
+keywords = ["python", "template", "package", "module", "cli"]
+description = "BeETL is a Python package for extracting data from one datasource, transforming it and loading it into another datasource."
+authors = [{ name = "Lars Scheibling", email = "lars.scheibling@hoglandet.se" }]
+license = { "text" = "GnuPG 3.0" }
+classifiers = [
+  "programming language :: python :: 3",
+  "license :: osi approved :: gnu general public license v3 (gplv3)",
+  "operating system :: os independent",
+]
+dynamic = ["version", "readme"]
+urls = { "github" = "https://github.com/Hoglandets-IT/beetl" }
+requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 requests
 polars[all]==1.14.0
 sqlalchemy
-faker
 pandas==2.2.3
 psycopg
 pyyaml
@@ -11,8 +10,12 @@ pymssql
 mysql-connector-python
 alive-progress
 tabulate
-testcontainers==4.8.2
 pymongo==4.10.1
+
 # Below packages are subdependencies of sqlalchemy
 cryptography
 psycopg2
+
+# Only used for testing
+testcontainers==4.8.2
+faker

--- a/setup.py
+++ b/setup.py
@@ -2,52 +2,33 @@
 import os
 from setuptools import setup, find_packages
 
-repository_name = 'beetl'
-module_name = 'beetl'
-python_min_version = ">=3.8"
+repository_name = "beetl"
+module_name = "beetl"
 
-with open('requirements.txt', 'r') as f:
+with open("requirements.txt", "r") as f:
     required_packages = f.read().splitlines()
 
 # Get key package details
-about = {}  # type: ignore
+version = {}  # type: ignore
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Load the __version__.py file from the plugin directory
-with open(os.path.join(here, 'src', module_name, '__version__.py')) as f:
-    exec(f.read(), about)
+with open(os.path.join(here, "src", module_name, "__version__.py")) as f:
+    exec(f.read(), version)
 
 # Load the README file and use it as the long_description for PyPI
-with open('README.md', 'r') as f:
+with open("README.md", "r") as f:
     readme = f.read()
 
 # Package configuration - for reference see:
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#id9
 setup(
-    name=about['__title__'],
-    description=about['__description__'],
     long_description=readme,
-    long_description_content_type='text/markdown',
-    version=about['__version__'],
-    author=about['__author__'],
-    author_email=about['__author_email__'],
-    url=about['__url__'],
+    long_description_content_type="text/markdown",
+    version=version["__version__"],
     packages=find_packages(where="src"),
     include_package_data=True,
-    python_requires=python_min_version,
     install_requires=required_packages,
-    license=about['__license__'],
     zip_safe=True,
     package_dir={"": "src"},
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent",
-    ],
-    keywords='python template package module cli',
-    entry_points = {
-        'console_scripts': [
-            'pytemplate=pytemplate.cli:main'
-        ]
-    }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,15 @@
 #!/usr/bin/env python3
 import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 repository_name = "beetl"
 module_name = "beetl"
 
-with open("requirements.txt", "r") as f:
-    required_packages = f.read().splitlines()
-
 # Get key package details
 version = {}  # type: ignore
-here = os.path.abspath(os.path.dirname(__file__))
 
 # Load the __version__.py file from the plugin directory
-with open(os.path.join(here, "src", module_name, "__version__.py")) as f:
+with open(os.path.join(os.getcwd(), "src", module_name, "__version__.py")) as f:
     exec(f.read(), version)
 
 # Load the README file and use it as the long_description for PyPI
@@ -26,9 +22,4 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     version=version["__version__"],
-    packages=find_packages(where="src"),
-    include_package_data=True,
-    install_requires=required_packages,
-    zip_safe=True,
-    package_dir={"": "src"},
 )

--- a/src/beetl/__version__.py
+++ b/src/beetl/__version__.py
@@ -10,7 +10,7 @@ gh_tag = os.getenv("GHTAG")
 gh_branch = os.getenv("GHBRANCH")
 gh_run = os.getenv("GHRUN")
 
-__version__ = "0.0.0"
+__version__ = "0.0.1"
 
 if gh_tag is not None:
     matches = re.findall(PRE_RELEASE, gh_tag)

--- a/src/beetl/__version__.py
+++ b/src/beetl/__version__.py
@@ -1,24 +1,22 @@
-"""Module information."""
+"""Module version information."""
 
 import os
+import re
 
-FALLBACK_VERSION = "1.0.0-rc.4"
+REGULAR_RELEASE = "(\d.\d.\d)"
+PRE_RELEASE = "(\d.\d.\d-rc.\d)"
 
-__title__ = "beetl"
-__description__ = """
-    BeETL is a Python package for extracting data from one datasource, 
-    transforming it and loading it into another datasource
-"""
+gh_tag = os.getenv("GHTAG")
+gh_branch = os.getenv("GHBRANCH")
+gh_run = os.getenv("GHRUN")
 
-__version__ = os.getenv("GHRELEASE", FALLBACK_VERSION)
-if os.getenv("GHRUN", False) and os.getenv("GHBRANCH", "develop") == "develop":
-    __version__ += f".{os.getenv('RUN_ID')}"
+__version__ = "0.0.0"
 
-if __version__ == "":
-    __version__ = FALLBACK_VERSION
-
-__author__ = "Lars Scheibling"
-__author_email__ = "lars.scheibling@hoglandet.se"
-__license__ = "GnuPG 3.0"
-
-__url__ = f"https://github.com/Hoglandets-IT/{__title__}"
+if gh_tag is not None:
+    matches = re.findall(PRE_RELEASE, gh_tag)
+    if matches and len(matches) == 1:
+        __version__ = matches[0]
+    else:
+        matches = re.findall(REGULAR_RELEASE, gh_tag)
+        if matches and len(matches) == 1:
+            __version__ = matches[0]


### PR DESCRIPTION
- Created pyproject.toml file containing static information and package dependencies for people who install beetl with pip.
- Revised the __version__.py to default to 0.0.1 and to set the version from the current pipeline trigger tag.
- Started using `python -m build` to build the package instead of setuptools directly.