### PR TITLE
v1.0.0 to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Sanity test the built package
       run: |
         python -m pip install ./dist/beetl-*.tar.gz
-        python ./tests/distribution_testing/test_distribution.py
+        python ./tests/distribution_testing/run_distribution_test.py
 
     - name: Publish to pypi
       if: github.event_name != 'pull_request'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "-s",
     "./tests",
     "-p",
-    "*.py"
+    "test_*.py"
   ],
   "python.testing.autoTestDiscoverOnSaveEnabled": true,
   "python.testing.unittestEnabled": true,

--- a/docs/getting-started/change-notes.md
+++ b/docs/getting-started/change-notes.md
@@ -1,5 +1,18 @@
 # Change Notes
 
+## 1.0.1
+
+### New features ⭐
+- [structs.staticfield](/transformers/structs.html#staticfield) now has an optional argument `only_add_if_missing` that defaults to `False`. When set to true the static field is only added if it missing from the data frame, compared to before where it would always overwrite it.
+
+### Bugfixes 🐛
+- In the 1.0.0 release a dependency was updated that caused the default behavior of the data frame comparer functionality to change so that null values were never considered equal, causing updates to be made on rows where there wasn't any change in values. This behavior has been fixed and nulls are now considered equal again.
+- In the 1.0.0 release the support for the [alternate column definition](/getting-started/columns.html#alternate-column-declaration) was accidentally removed. Support for them has been added again.
+- Some minor typos in the documentation was fixed.
+
+### Quality control 🧐
+- Unit tests has been implemented for all new and fixed functionality to ensure they continue to work the way they intend to.
+
 ## 1.0.0
 
 ### New features ⭐

--- a/docs/transformers/frames.md
+++ b/docs/transformers/frames.md
@@ -134,7 +134,7 @@ sourceTransformers:
       # The fields to copy from the parent object
       colMap:
         name: vm_name
-  - transformer: string.substring
+  - transformer: strings.substring
     config:
       inField: disk_name
       start: -2

--- a/docs/transformers/structs.md
+++ b/docs/transformers/structs.md
@@ -94,4 +94,7 @@ Adds a static field to the dataset
   config:
     field: new_field
     value: "static_value"
+    # only add the static field if it is missing from the dataset
+    # default=False
+    only_add_if_missing: False
 ```

--- a/src/beetl/beetl.py
+++ b/src/beetl/beetl.py
@@ -123,7 +123,7 @@ class Beetl:
 
             # Get rows that exist in both and have differing values (Updates)
             update = source.join(destination, on=keys, how="semi").join(
-                destination, on=column_names, how="anti"
+                destination, on=column_names, how="anti", join_nulls=True
             )
 
             # Get rows that only exist in destination (Deletes)
@@ -154,7 +154,8 @@ class Beetl:
     def _initialize_columns_if_empty(source, columns):
         if len(source) == 0 and source.width == 0:
             for col in columns:
-                source = source.with_columns(pl.Series(col.name, dtype=col.type))
+                source = source.with_columns(
+                    pl.Series(col.name, dtype=col.type))
         return source
 
     @staticmethod
@@ -270,9 +271,12 @@ class Beetl:
             if dry_run:
                 dry_run_results.append(
                     ComparisonResult(
-                        self.runTransformers(create, sync.insertionTransformers, sync),
-                        self.runTransformers(update, sync.insertionTransformers, sync),
-                        self.runTransformers(delete, sync.deletionTransformers, sync),
+                        self.runTransformers(
+                            create, sync.insertionTransformers, sync),
+                        self.runTransformers(
+                            update, sync.insertionTransformers, sync),
+                        self.runTransformers(
+                            delete, sync.deletionTransformers, sync),
                     )
                 )
                 continue
@@ -281,7 +285,8 @@ class Beetl:
             amount["inserts"] = 0
             if len(create):
                 amount["inserts"] = sync.destination.insert(
-                    self.runTransformers(create, sync.insertionTransformers, sync)
+                    self.runTransformers(
+                        create, sync.insertionTransformers, sync)
                 )
 
             self.benchmark("Finished inserts, starting updates")
@@ -289,14 +294,16 @@ class Beetl:
             amount["updates"] = 0
             if len(update):
                 amount["updates"] = sync.destination.update(
-                    self.runTransformers(update, sync.insertionTransformers, sync)
+                    self.runTransformers(
+                        update, sync.insertionTransformers, sync)
                 )
 
             self.benchmark("Finished updates, starting deletes")
             amount["deletes"] = 0
             if len(delete):
                 amount["deletes"] = sync.destination.delete(
-                    self.runTransformers(delete, sync.deletionTransformers, sync)
+                    self.runTransformers(
+                        delete, sync.deletionTransformers, sync)
                 )
 
             self.benchmark("Finished deletes, sync finished")
@@ -312,7 +319,8 @@ class Beetl:
 
         print(
             "\r\n\r\n"
-            + tabulate(allAmounts, headers=["Sync", "Inserts", "Updates", "Deletes"])
+            + tabulate(allAmounts,
+                       headers=["Sync", "Inserts", "Updates", "Deletes"])
         )
 
         return SyncResult(allAmounts)

--- a/src/beetl/transformers/structs.py
+++ b/src/beetl/transformers/structs.py
@@ -7,17 +7,21 @@ import json
 @register_transformer_class("structs")
 class StructTransformers(TransformerInterface):
     @staticmethod
-    def staticfield(data: pl.DataFrame, field: str, value):
+    def staticfield(data: pl.DataFrame, field: str, value: Any, only_add_if_missing: bool = False):
         """Add a struct field to the DataFrame
 
         Args:
             data (pl.DataFrame): The dataFrame to modify
             field (str): The field to add
             value (str): The value of the field to add
+            only_add_if_missing (bool, optional): If true, the field will only be added if it does not already exist. Defaults to False.
 
         Returns:
             pl.DataFrame: The resulting DataFrame
         """
+        if only_add_if_missing and field in data.columns:
+            return data
+
         data = data.with_columns(pl.Series(field, [value] * len(data)))
         return data
 
@@ -103,7 +107,8 @@ class StructTransformers(TransformerInterface):
         rows = len(data)
         newStructs = []
         for i in range(rows):
-            newStructs.append({name: data[field][i] for name, field in map.items()})
+            newStructs.append({name: data[field][i]
+                              for name, field in map.items()})
 
         series = pl.Series(outField, newStructs)
         data = data.with_columns(series)

--- a/tests/distribution_testing/run_distribution_test.py
+++ b/tests/distribution_testing/run_distribution_test.py
@@ -1,7 +1,7 @@
 from beetl.beetl import Beetl, BeetlConfig, Result
 
 
-def test_distribution():
+def distribution_test():
     """Simple test just to make sure that we can import beetl, create a config and run the sync.
     It uses the installed version of beetl, not the source files."""
     config = BeetlConfig(get_config())
@@ -76,4 +76,4 @@ class ManualResult(Result):
 
 
 if __name__ == "__main__":
-    test_distribution()
+    distribution_test()

--- a/tests/unit_testing/test_config.py
+++ b/tests/unit_testing/test_config.py
@@ -1,0 +1,76 @@
+
+from src.beetl.beetl import BeetlConfig
+import unittest
+from polars import Int32, Utf8
+
+
+class UnitTestBeetlConfig(unittest.TestCase):
+
+    def config_with_columns_as_list(self):
+        return {
+            "version": "V1",
+            "sources": [{"name": "src", "type": "Static", "connection": {"static": [{"id": 1, "name": "foo"}]}}],
+            "sync": [{
+                "source": "src",
+                "sourceConfig": {},
+                "destination": "src",
+                "destinationConfig": {},
+                "comparisonColumns": [
+                    {
+                        "name": "id",
+                        "type": "Int32",
+                        "unique": True
+                    },
+                    {
+                        "name": "name",
+                        "type": "Utf8"
+                    }
+                ]
+            }]
+        }
+
+    def test_config_init__comparison_columns_as_list__fields_are_propagated(self):
+        result = BeetlConfig(self.config_with_columns_as_list())
+
+        id = result.sync_list[0].comparisonColumns[0]
+        self.assertEqual(id.name, "id")
+        self.assertEqual(id.type, Int32)
+        self.assertTrue(id.unique)
+
+    def test_config_init__comparison_columns_as_list__fields_without_unique_defaults_to_false(self):
+        result = BeetlConfig(self.config_with_columns_as_list())
+
+        id = result.sync_list[0].comparisonColumns[1]
+        self.assertEqual(id.name, "name")
+        self.assertEqual(id.type, Utf8)
+        self.assertFalse(id.unique)
+
+    def config_with_columns_as_dict(self):
+        return {
+            "version": "V1",
+            "sources": [{"name": "src", "type": "Static", "connection": {"static": [{"id": 1, "name": "foo"}]}}],
+            "sync": [{
+                "source": "src",
+                "sourceConfig": {},
+                "destination": "src",
+                "destinationConfig": {},
+                "comparisonColumns": {
+                    "id": "Int32",
+                    "name": "Utf8"
+                }
+            }]
+        }
+
+    def test_config_init__comparision_columns_as_dict__first_field_is_unique(self):
+        result = BeetlConfig(self.config_with_columns_as_dict())
+        id = result.sync_list[0].comparisonColumns[0]
+        self.assertEqual(id.name, "id")
+        self.assertEqual(id.type, Int32)
+        self.assertTrue(id.unique)
+
+    def test_config_init__comparision_columns_as_dict__second_field_is_not_unique(self):
+        result = BeetlConfig(self.config_with_columns_as_dict())
+        name = result.sync_list[0].comparisonColumns[1]
+        self.assertEqual(name.name, "name")
+        self.assertEqual(name.type, Utf8)
+        self.assertFalse(name.unique)

--- a/tests/unit_testing/transformers/test_structs.py
+++ b/tests/unit_testing/transformers/test_structs.py
@@ -6,7 +6,7 @@ from src.beetl.transformers.structs import StructTransformers
 
 
 class UnitTestStructsTransformers(unittest.TestCase):
-    def test_jsonpath_single_dollar_seletor(self):
+    def test_jsonpath__single_dollar_selector__sets_out_field_to_in_field(self):
         # arrange
         inField = "field1"
         outField = "field2"
@@ -17,13 +17,14 @@ class UnitTestStructsTransformers(unittest.TestCase):
         transformer = StructTransformers()
 
         # act
-        result = transformer.jsonpath(data, inField, outField, jsonPath, defaultValue)
+        result = transformer.jsonpath(
+            data, inField, outField, jsonPath, defaultValue)
 
         # assert
         resultingString = result[outField][0]
         self.assertEqual(expected, resultingString)
 
-    def test_jsonpath_property_in_object(self):
+    def test_jsonpath__property_selector_on_root__sets_out_field_to_value_of_property_on_object(self):
         # arrange
         inField = "field1"
         outField = "field2"
@@ -36,13 +37,14 @@ class UnitTestStructsTransformers(unittest.TestCase):
         transformer = StructTransformers()
 
         # act
-        result = transformer.jsonpath(data, inField, outField, jsonPath, defaultValue)
+        result = transformer.jsonpath(
+            data, inField, outField, jsonPath, defaultValue)
 
         # assert
         resultingString = result[outField][0]
         self.assertEqual(expected, resultingString)
 
-    def test_jsonpath_property_in_object_in_list(self):
+    def test_jsonpath__property_selector_on_object_in_list__sets_out_field_to_value_of_property_on_object_in_list(self):
         # arrange
         inField = "field1"
         outField = "field2"
@@ -50,12 +52,57 @@ class UnitTestStructsTransformers(unittest.TestCase):
         defaultValue = "default"
         value = "value"
         expected = [value]
-        data = DataFrame().with_columns(Series(inField, [[{"nested_property": value}]]))
+        data = DataFrame().with_columns(
+            Series(inField, [[{"nested_property": value}]]))
         transformer = StructTransformers()
 
         # act
-        result = transformer.jsonpath(data, inField, outField, jsonPath, defaultValue)
+        result = transformer.jsonpath(
+            data, inField, outField, jsonPath, defaultValue)
 
         # assert
         resultingString = list(result[outField][0])
         self.assertListEqual(expected, resultingString)
+
+    def test_staticfield__with_string_value__field_is_added_with_value(self):
+        field = "field2"
+        value = "value"
+        data = DataFrame([{"field1": 1}])
+        transformer = StructTransformers()
+
+        result = transformer.staticfield(data, field, value)
+
+        self.assertEqual(value, result[field][0])
+
+    def test_staticfield__with_none_value__field_is_added_with_value(self):
+        field = "field2"
+        value = None
+        data = DataFrame([{"field1": 1}])
+        transformer = StructTransformers()
+
+        result = transformer.staticfield(data, field, value)
+
+        self.assertEqual(value, result[field][0])
+
+    def test_staticfield__field_already_exists__field_is_overwritten(self):
+        field = "field1"
+        value = "value"
+        data = DataFrame([{"field1": 1}])
+        transformer = StructTransformers()
+
+        result = transformer.staticfield(data, field, value)
+
+        self.assertEqual(value, result[field][0])
+
+    def test_staticfield__field_already_exists_and_only_add_if_missing_is_true__field_is_not_overwritten(self):
+        field = "field1"
+        value = "value"
+        original_value = 1
+        data = DataFrame([{"field1": original_value}])
+        transformer = StructTransformers()
+        only_add_if_missing = True
+
+        result = transformer.staticfield(
+            data, field, value, only_add_if_missing=only_add_if_missing)
+
+        self.assertEqual(original_value, result[field][0])


### PR DESCRIPTION
- Re-enable support of alternative column definition
- Fixed so that the comparer correctly treats nulls as equal each other.
- Added support in the struct.staticfield to only add the field if it is missing from the data frame, prohibiting an overwrite.
- Updated wiki and changenotes to be ready for a 1.0.1 release.