### PR TITLE
v1.0.3 to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Note: Even though some of the configuration below is in YAML format, you can als
 - [Getting Started](#getting-started)
 - [Development Environment](#development-environment)
 - [Documentation](https://beetl.docs.hoglan.dev/)
+- [Change Notes](https://beetl.docs.hoglan.dev/getting-started/change-notes.html)
 - [Source Code](https://github.com/hoglandets-it/beetl)
 
 ## Minimal example

--- a/docs/getting-started/change-notes.md
+++ b/docs/getting-started/change-notes.md
@@ -1,8 +1,18 @@
 # Change Notes
 
+## 1.0.3
+
+### Changes 🔄️
+- Started using connect and disconnect on sources before and after syncing to enable atomic operations for the sources that support it. Currently only Sqlserver supports this.
+- Defined psycopg dependency as per their documentation.
+
+### Bugfixes 🐛
+- Fixed bug where the transformer int.fillna did not fill nulls.
+- Fixed bug where multiple invocations of `Beetl.sync` run after each other aggregated the number of syncs instead of creating separate results.
+
 ## 1.0.2
 
-### Changes
+### Changes 🔄️
 - Dependency to psycopg2 for postgresql connections was removed. Beetl now only requires psycopg.
 
 ## 1.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "polars[all]>=1.14.0",
   "sqlalchemy",
   "pandas>=2.2.3",
-  "psycopg",
+  "psycopg[binary,pool]>=3.2.3",
   "pyyaml",
   "pymysql",
   "pyodbc",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests
 polars[all]==1.14.0
 sqlalchemy
 pandas==2.2.3
-psycopg
+psycopg[binary,pool]==3.2.3
 pyyaml
 pymysql
 pyodbc

--- a/src/beetl/beetl.py
+++ b/src/beetl/beetl.py
@@ -224,9 +224,12 @@ class Beetl:
                 print(f"Starting sync: {sync.name}")
             else:
                 print(f"Starting sync {i}")
+            sync.source.connect()
             source_data = sync.source.query(sync.sourceConfig)
+            sync.source.disconnect()
             self.benchmark("Finished data retrieval from source")
 
+            sync.destination.connect()
             destination_data = sync.destination.query(sync.destinationConfig)
             self.benchmark("Finished data retrieval from destination")
 
@@ -279,6 +282,7 @@ class Beetl:
                             delete, sync.deletionTransformers, sync),
                     )
                 )
+                sync.destination.disconnect()
                 continue
 
             self.benchmark("Starting database operations")
@@ -313,6 +317,8 @@ class Beetl:
             print("Deleted: " + str(amount["deletes"]))
 
             allAmounts.append([sync.name, *amount.values()])
+
+            sync.destination.disconnect()
 
         if dry_run:
             return dry_run_results

--- a/src/beetl/result.py
+++ b/src/beetl/result.py
@@ -2,10 +2,10 @@ from typing import List, Tuple
 
 
 class Result:
-    updates = 0
-    inserts = 0
-    deletes = 0
-    names = []
+    updates: int = 0
+    inserts: int = 0
+    deletes: int = 0
+    names: Tuple[str, ...] = ()
 
     def __str__(self) -> str:
         return f"Result: {self.inserts} inserts, {self.updates} updates, {self.deletes} deletes across {len(self.names)} syncs"
@@ -27,8 +27,8 @@ class Result:
 class SyncResult(Result):
     def __init__(self, results: List[Tuple[str, int, int, int]] = []):
         super().__init__()
+        self.names = tuple([result[0] for result in results])
         for result in results:
-            self.names.append(result[0])
             self.inserts += result[1] or 0
             self.updates += result[2] or 0
             self.deletes += result[3] or 0

--- a/src/beetl/sources/interface.py
+++ b/src/beetl/sources/interface.py
@@ -164,6 +164,12 @@ class SourceInterface:
         """
         raise NotImplementedError
 
+    def connect(self):
+        self._connect()
+
+    def disconnect(self):
+        self._disconnect()
+
     def query(self, params=None):
         """Formats the query according to the column specification
 

--- a/src/beetl/transformers/integer.py
+++ b/src/beetl/transformers/integer.py
@@ -1,6 +1,9 @@
 import polars as pl
 from .interface import TransformerInterface, register_transformer_class
 
+NAN_SUPPORTED_TYPES = [pl.Decimal, pl.Float32, pl.Float64, pl.Int8,
+                       pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64]
+
 
 @register_transformer_class("int")
 class IntegerTransformer(TransformerInterface):
@@ -27,7 +30,7 @@ class IntegerTransformer(TransformerInterface):
 
     @staticmethod
     def fillna(data: pl.DataFrame, inField: str, outField: str = None, value: int = 0) -> pl.DataFrame:
-        """Fill the missing values in a given column with the given value
+        """Fill the missing NaN and null values in a given column with the given value
 
         Args:
             data (pl.DataFrame): The dataFrame to modify
@@ -39,11 +42,11 @@ class IntegerTransformer(TransformerInterface):
             pl.DataFrame: The resulting DataFrame
         """
 
-        try:
+        data = data.with_columns(data[inField].fill_null(
+            value).alias(outField or inField))
+
+        if data[inField].dtype in NAN_SUPPORTED_TYPES:
             data = data.with_columns(data[inField].fill_nan(
-                value).alias(outField or inField))
-        except Exception:
-            data = data.with_columns(data[inField].fill_null(
                 value).alias(outField or inField))
 
         return data

--- a/tests/unit_testing/test_result.py
+++ b/tests/unit_testing/test_result.py
@@ -1,0 +1,48 @@
+
+import unittest
+from src.beetl.result import SyncResult
+
+
+class TestResult(unittest.TestCase):
+
+    def test_str__with_one_insert_two_updates_three_deletes_one_sync__returns_properly_formatted_string(self):
+        expected = "Result: 1 inserts, 2 updates, 3 deletes across 1 syncs"
+        result = SyncResult([("Sync One", 1, 2, 3)])
+        self.assertEqual(expected, result.__str__())
+
+    def test_repr__with_one_insert_two_updates_three_deletes_one_sync__returns_properly_formatted_string(self):
+        expected = "Result: 1 inserts, 2 updates, 3 deletes across 1 syncs"
+        result = SyncResult([("Sync One", 1, 2, 3)])
+        self.assertEqual(expected, result.__repr__())
+
+    def test_eq__with_same_inserts_updates_deletes__returns_true(self):
+        result1 = SyncResult([("Sync One", 1, 2, 3)])
+        result2 = SyncResult([("Sync One", 1, 2, 3)])
+        self.assertEqual(result1, result2)
+
+    def test_eq__with_different_inserts__returns_false(self):
+        result1 = SyncResult([("Sync One", 1, 2, 3)])
+        result2 = SyncResult([("Sync One", 2, 2, 3)])
+        self.assertNotEqual(result1, result2)
+
+    def test_eq__with_different_updates__returns_false(self):
+        result1 = SyncResult([("Sync One", 1, 2, 3)])
+        result2 = SyncResult([("Sync One", 1, 3, 3)])
+        self.assertNotEqual(result1, result2)
+
+    def test_eq__with_different_deletes__returns_false(self):
+        result1 = SyncResult([("Sync One", 1, 2, 3)])
+        result2 = SyncResult([("Sync One", 1, 2, 4)])
+        self.assertNotEqual(result1, result2)
+
+    def test_eq__with_different_sync_names__returns_true(self):
+        result1 = SyncResult([("Sync One", 1, 2, 3)])
+        result2 = SyncResult([("Sync Two", 1, 2, 3)])
+        self.assertEqual(result1, result2)
+
+    def test_sync_result_init__list_of_sync_tuples__properly_calculates_inserts_updates_deletes(self):
+        result = SyncResult([("Sync One", 1, 2, 3), ("Sync Two", 4, 5, 6)])
+        self.assertEqual(5, result.inserts)
+        self.assertEqual(7, result.updates)
+        self.assertEqual(9, result.deletes)
+        self.assertEqual(("Sync One", "Sync Two"), result.names)

--- a/tests/unit_testing/transformers/test_integer.py
+++ b/tests/unit_testing/transformers/test_integer.py
@@ -1,0 +1,56 @@
+
+import unittest
+
+from polars import DataFrame, Series, Float64, Utf8
+
+from src.beetl.transformers.integer import IntegerTransformer
+
+
+class UnitTestIntegerTransformers(unittest.TestCase):
+
+    def test_fillna__integer_field_with_nulls__nulls_are_filled_with_value(self):
+        # arrange
+        inField = "field1"
+        value = 1
+        data = DataFrame().with_columns(Series(inField, [None, None, value]))
+        transformer = IntegerTransformer()
+
+        # act
+        result = transformer.fillna(data, inField, value=value)
+
+        # assert
+        self.assertEqual([value, value, value],
+                         result[inField].to_list())
+
+    def test_fillna__nan_supported_field_type_with_nans__nans_are_filled_with_value(self):
+        # arrange
+        inField = "field1"
+        value = 1
+        nan = float("nan")
+        data = DataFrame().with_columns(
+            Series(inField, [nan, nan, value], dtype=Float64))
+        transformer = IntegerTransformer()
+
+        # act
+        result = transformer.fillna(data, inField, value=value)
+
+        # assert
+        self.assertEqual([value, value, value],
+                         result[inField].to_list())
+
+    def test_fillna__not_nan_supported_field_type_with_nans__nans_are_not_filled_with_value(self):
+        # arrange
+        inField = "field1"
+        value = "value"
+        nan_value = float("nan")
+        data = DataFrame().with_columns(
+            Series(inField, [nan_value, nan_value, value], dtype=Utf8, strict=False))
+        transformer = IntegerTransformer()
+
+        # act
+        result = transformer.fillna(data, inField, value=value)
+
+        # assert
+        nan_string = 'NaN'
+        self.assertEqual([nan_string, nan_string, value],
+                         result[inField].to_list())

--- a/tests/unit_testing/transformers/test_itop.py
+++ b/tests/unit_testing/transformers/test_itop.py
@@ -1,0 +1,93 @@
+
+import unittest
+
+from polars import DataFrame, Series
+
+from src.beetl.transformers.itop import ItopTransformer
+
+
+class UnitTestItopTransformers(unittest.TestCase):
+    def test_orgcode__single_field__sets_out_field_to_hash_of_field(self):
+        # arrange
+        inFields = ["field1"]
+        value = "a"
+        outField = "code"
+        toplevel = "Beetl"
+        expected = "e4d19a8f608ba8bf1d0dd26583174f12dd4a2290"
+        data = DataFrame().with_columns(Series(inFields[0], [value]))
+        transformer = ItopTransformer()
+
+        # act
+        result = transformer.orgcode(data, inFields, outField, toplevel)
+
+        # assert
+        resultingString = result[outField][0]
+        self.assertEqual(expected, resultingString)
+
+    def test_orgcode__multi_field__sets_out_field_to_hash_of_fields(self):
+        # arrange
+        inFields = ["field1", "field2"]
+        values = ["a", "b"]
+        outField = "code"
+        toplevel = "Beetl"
+        expected = "34613675289b022b729fde2f9ba67b331aafcb99"
+        data = DataFrame().with_columns(
+            Series(inFields[0], [values[0]]), Series(inFields[1], [values[1]]))
+        transformer = ItopTransformer()
+
+        # act
+        result = transformer.orgcode(data, inFields, outField, toplevel)
+
+        # assert
+        resultingString = result[outField][0]
+        self.assertEqual(expected, resultingString)
+
+    def test_orgcode__when_passed_differently_cased_values__casing_is_normalized_before_hashing(self):
+        # arrange
+        inFields = ["field1"]
+        value = "a"
+        outField = "code"
+        toplevel = "Beetl"
+        data = DataFrame().with_columns(Series(inFields[0], [value]))
+        transformer = ItopTransformer()
+
+        # act
+        uppercaseData = DataFrame().with_columns(
+            Series(inFields[0], [value.upper()]))
+        uppercaseResult = transformer.orgcode(
+            uppercaseData, inFields, outField, toplevel)
+        uppercaseHash = uppercaseResult[outField][0]
+
+        lowercaseData = DataFrame().with_columns(
+            Series(inFields[0], [value.lower()]))
+        lowercaseResult = transformer.orgcode(
+            lowercaseData, inFields, outField, toplevel)
+        lowercaseHash = lowercaseResult[outField][0]
+
+        # assert
+        self.assertEqual(uppercaseHash, lowercaseHash)
+
+    def test_orgcode__when_comparing_hash_to_hash_from_same_value_plus_trailing_space__hashes_are_different(self):
+        # arrange
+        inFields = ["field1"]
+        value = "a"
+        outField = "code"
+        toplevel = "Beetl"
+        data = DataFrame().with_columns(Series(inFields[0], [value]))
+        transformer = ItopTransformer()
+
+        # act
+        no_space_data = DataFrame().with_columns(
+            Series(inFields[0], [value]))
+        no_space_result = transformer.orgcode(
+            no_space_data, inFields, outField, toplevel)
+        no_space_hash = no_space_result[outField][0]
+
+        with_space_data = DataFrame().with_columns(
+            Series(inFields[0], [value + " "]))
+        with_space_result = transformer.orgcode(
+            with_space_data, inFields, outField, toplevel)
+        with_space_hash = with_space_result[outField][0]
+
+        # assert
+        self.assertNotEqual(with_space_hash, no_space_hash)


### PR DESCRIPTION
- Fix bug where multiple invocations of `Beetl.sync` run after each other aggregated the number of syncs instead of creating separate results.
- Started using connect and disconnect on sources before and after syncing to enable atomic operations for the sources that support it.
- Fixed bug where the transformer int.fillna did not fill nulls.
- Defined psycopg dependency as per their documentation.