### PR TITLE
v1.0.4 to main

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,8 @@
 				"ms-python.debugpy",
 				"ms-python.autopep8",
 				"github.vscode-github-actions",
-				"tamasfe.even-better-toml"
+				"tamasfe.even-better-toml",
+				"redhat.vscode-xml"
 			]
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Beetl(config).sync()
 ```bash
 #/bin/bash
 python -m pip install beetl
+
+# If you need to use xsl transformations
+python -m pip install beetl[xsl]
 ```
 
 ### From Source

--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,71 @@
+import polars as pl
+
+
+def diff_update(update: pl.DataFrame, destination: pl.DataFrame, column_names_props: list[str], key_columns: list[str], ignore_dates=False) -> tuple[list[pl.DataFrame], set[str]]:
+    """
+    This function compares two dataframes and returns a list of dataframes with the differences and a set with the keys that have differences across the whole dataframe.
+    It is not very efficient, but very helpful when doing data validation on a sync that is going to affect an already existing dataset.
+
+    Args:
+        update (pl.DataFrame): The dataframe returned by the beetl comparer containing the items going to be updated.
+        destination (pl.DataFrame): The destination dataframe after being transformed using the source transformers.
+        column_names_props (list[str]): The list of column names that are going to be compared.
+        key_columns (list[str]): The list of columns that are going to be used as keys.
+        ignore_dates (bool, optional): If true, it will ignore columns that have "date" in their name. Defaults to False.
+
+    Returns:
+        tuple[list[pl.DataFrame], set[str]]: A tuple containing a list of dataframes with the differences and a set with the keys that have differences across the whole dataframe
+    """
+    column_names = [*column_names_props]
+    if ignore_dates:
+        column_names = [
+            name for name in column_names if "date" not in name.lower()]
+
+    calcultated_dataframe_diffs = []
+    keys_that_differ_across_whole_dataset = set()
+
+    for row_index in range(update.height):
+        current_row_keys_dataframe = update.select(key_columns)[row_index]
+        current_update_dataframe_row = update.join(
+            current_row_keys_dataframe, on=key_columns).select(column_names)
+        current_destination_dataframe_row = destination.join(
+            current_row_keys_dataframe, on=key_columns).select(column_names)
+
+        multiple_rows_found_using_keys = current_update_dataframe_row.height > 1 or current_destination_dataframe_row.height > 1
+        if multiple_rows_found_using_keys:
+            raise Exception(
+                f"Multiple rows were found when using the keys {key_columns} for row index {row_index} in the update dataset. This is not allowed since it will cause beetl to miss or overwrite data that should't be overwritten.")
+
+        current_row_comparison_dataframe = current_update_dataframe_row == current_destination_dataframe_row
+        current_row_comparison_dict = current_row_comparison_dataframe.to_dict()
+        keys_that_differ_in_current_row = []
+        for key, value in current_row_comparison_dict.items():
+            if not value[0]:
+                keys_that_differ_in_current_row.append(key)
+
+        key_values_for_current_row = list(
+            map(str, list(current_row_keys_dataframe.to_dicts()[0].values())))
+
+        current_diff_dataframe = pl.DataFrame().with_columns(
+            pl.Series("dataset", ["update", "destination"]), pl.Series('keys', [key_values_for_current_row, key_values_for_current_row]))
+        current_row_has_diff = False
+        for key in keys_that_differ_in_current_row:
+            value1 = current_update_dataframe_row[key][0]
+            value2 = current_destination_dataframe_row[key][0]
+            if value1 is None and value2 is None:
+                continue
+            if value1 == value2:
+                continue
+            series = pl.Series(key, [value1, value2])
+            current_diff_dataframe = current_diff_dataframe.with_columns(
+                series)
+            current_row_has_diff = True
+
+        if not current_row_has_diff:
+            continue
+
+        calcultated_dataframe_diffs.append(current_diff_dataframe)
+        keys_that_differ_across_whole_dataset.update(
+            keys_that_differ_in_current_row)
+
+    return (calcultated_dataframe_diffs, keys_that_differ_across_whole_dataset)

--- a/docs/getting-started/change-notes.md
+++ b/docs/getting-started/change-notes.md
@@ -1,5 +1,18 @@
 # Change Notes
 
+## 1.0.4
+### Changes ️️🔄️
+- It is now possible to use Xml files as a data source and destination. Read more about it in the [docs](/sources/xml.html).
+- The transformer [strings.format](/transformers/strings.html#Format) has been added, allowing values to be interpolated into string templates.
+- `ComparisonResult` returned when running beetl in `dry-run` mode now has a __str__ and __repr__ implementation describing the changes in plane text, making them printable.
+
+### Bugfixes 🐛
+- Fixed a bug where the Sqlserver source incorrectly replaced the `mysql://` protocol part of the connection string instead of `mssql://`.
+- Fixed a bug in the underlying column validation logic for transformers that raised an exception if the amount of columns to validate was the same as the total amount of columns on the dataframe.
+
+### For developers 🧑‍💻
+- Added new update diff tool in `compare.py` that can be used to figure out why a row needs updating. Read the docstring for the `diff_update` tool to understand how to use it. As of right now this is just an internal tool.
+
 ## 1.0.3
 
 ### Changes 🔄️

--- a/docs/sources/xml.md
+++ b/docs/sources/xml.md
@@ -1,0 +1,249 @@
+# Xml
+The Xml source will load and save data to local Xml files.
+Under the hood it uses the etree module to do the parsing.
+
+- Type identifier: `Xml`
+
+## Source Configuration 
+Declare the path to your xml file.
+```yaml
+sources:
+  - name: src
+    type: Xml
+    connection:
+      settings:
+        # path: <string>, (mandatory)
+        # The filepath of your xml file.
+        path: "my-file.xml"
+        # encoding: <string>, (optional, default="utf-8")
+        # The encoding of your xml file.
+        encoding: "utf-8"
+```
+
+## Sync Settings
+Declare how your file should be read, and if used as destination how the file should be written.
+```yaml
+sync:
+  - source: src
+    sourceConfig:
+      # xpath: <string>, (optional, default="./*", only used when configured as source)
+      # Querystring defining how the xml file should be read, see the link below.
+      # Etree supported xpath syntax https://docs.python.org/3/library/xml.etree.elementtree.html#supported-xpath-syntax
+      # E.g: ".//People" will select all all People objects on all levels.  
+      xpath: ".//People"
+      # type: <Dict[str, str]>, (optional, only used when configured as source)
+      # Declares what types the properties will be parsed as.
+      # The types supported are string representations of the polars datatypes, same as used in the rest of the project.
+      # E.g: {"Name": "Utf-8", "Age": "Int32"}
+      types:
+        Name: Utf-8
+        Age: Int32
+      # xsl: <string>, (optional, default=None)
+      # Can be used to perform transformations on the xml before parsing it.
+      # Recommended to use if you need to change the structure of your data.
+      # Requires lxml to be installed, see examples below.
+      xsl: null
+    destination: dst
+    destinationConfig:
+      # unique_columns: <set[string]>, (mandatory, only used when configured as destination)
+      # Used when performing mutations to identify unique rows.
+      unique_columns:
+        - Name
+      # root_name: <string>, (optional, default="root", only used when configured as destination)
+      # Name of the root element in the resulting xml.
+      root_name: root
+      # row_name: <string>, (optional, default="row", only used when configured as destination)
+      # Name of the row elemets in the resulting xml.
+      row_name: row
+```
+
+## Good to know's
+Since the datasource for this source is a plain file beetl will hold all the changes in memory until all the mutations have been done to an in memory dataframe behind the scenes. It will then flush whole dataframe to file. 
+
+This means that when you're working with the xml source as a destination you will keep an extra copy of all the data in memory.
+
+On the upside this is probably more speed efficient than constantly querying and updating portions of the xml file on disk.
+
+
+## Example
+
+### From Xml to Xml
+This example syncs three people from one xml file into another.
+
+#### What will happen?
+**People of xml source**
+
+```xml
+<PersonResponse>
+  <Body>
+    <PBSExportResponse>
+      <PBSExportResult>
+        <NewDataSet>
+          <PERSON>
+            <Id>1</Id>
+            <Name>John Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+          <PERSON>
+            <Id>10</Id>
+            <Name>Jimmy Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+          <PERSON>
+            <Id>11</Id>
+            <Name>Jane Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+        </NewDataSet>
+      </PBSExportResult>
+    </PBSExportResponse>
+  </Body>
+</PersonResponse>
+```
+
+Destination file is empty or does not exist.
+
+**Result**
+- All persons will be synced to the destination xml as rows on a root element.
+- Id has been removed
+
+
+**People of database 2 after sync**
+
+```xml
+<PersonExport>
+  <Person>
+    <Name>John Doe</Name>
+    <Age>25</Age>
+  </Person>
+  <Person>
+    <Name>Jimmy Doe</Name>
+    <Age>25</Age>
+  </Person>
+  <Person>
+    <Name>Jane Doe</Name>
+    <Age>25</Age>
+  </Person>
+</PersonExport>
+```
+
+#### Configuration
+
+```yaml
+sources:
+  - name: src
+    type: Xml
+    connection:
+      settings:
+        path: source.xml
+  - name: dst
+    type: Xml
+    connection:
+      settings:
+        path: destination.xml
+sync:
+  - name: Syncing persons
+    source: src
+    sourceConfig:
+      xpath: .//PERSON
+      types:
+        Name: Utf-8
+        Age: Int32
+    destination: dst
+    destinationConfig:
+      unique_columns:
+        - Name
+      root_name: PersonExport
+      row_name: Person
+    comparisonColumns:
+      - Name: Utf-8
+      - Age: Int32
+    # Only keep the columns we want
+    sourceTransformers:
+      - transformer: frames.project_columns
+        config:
+          columns:
+            - Name
+            - Age
+```
+
+### Using XSL to transform the data
+This is a short example showcasing how the xsl property can be used. This is not in any way, shape or form a guide to xsl's themselves.
+
+:::info
+To enable XSL you need to install the lxml parser. It can be done either by installing beetl using the xsl tag `pip install beetl[xsl]` or independently `pip install lxml`.
+:::
+
+The XSL tranformations are applied prior to beetl converting the XML to a dataframe.
+
+We're going to restructure this xml from being persons with addresses to addresses with person names.
+
+**Source**
+```xml
+<body>
+  <person>
+    <name>Sarah</name>
+    <address>
+      <street>1 main st</street>
+    </address>
+    <address>
+      <street>2 main st</street>
+    </address>
+  </person>
+  <person>
+    <name>Sophie</name>
+    <address>
+      <street>3 main st</street>
+    </address>
+    <address>
+      <street>4 main st</street>
+    </address>
+  </person>
+</body>
+```
+
+By specifying a xsl like this and providing it as a string to the xsl parameter:
+
+```xsl
+<?xml version="1.0" encoding="UTF-8"?>
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">xsl
+            <xsl:output method="xml" indent="yes"/>
+            <xsl:template match="//body">
+                <Output>
+                    <xsl:for-each select=".//person">
+                        <xsl:variable name="person_name" select=".//name"/>
+                        <xsl:for-each select=".//address">
+                            <Record>
+                                <name><xsl:value-of select="$person_name"/></name>
+                                <street><xsl:value-of select=".//street"/></street>
+                            </Record>
+                        </xsl:for-each>
+                    </xsl:for-each>
+                </Output>
+            </xsl:template>
+        </xsl:stylesheet>
+```
+
+The transformed xml that will be parsed by beetl will be this:
+
+```xml
+<body>
+  <address>
+    <name>Sarah</name>
+    <street>1 main st</street>
+  </address>
+  <address>
+    <name>Sarah</name>
+    <street>2 main st</street>
+  </address>
+  <address>
+    <name>Sophie</name>
+    <street>3 main st</street>
+  </address>
+  <address>
+    <name>Sophie</name>
+    <street>4 main st</street>
+  </address>
+</body>
+```
+

--- a/docs/transformers/strings.md
+++ b/docs/transformers/strings.md
@@ -176,3 +176,24 @@ Casts values of a string column into [bson.ObjectId's](https://pymongo.readthedo
     inField: field_name
 
 ```
+
+## Format
+Interpolates the original value into a string template.
+
+If you have the value `123` and the template `The value is {value}!` the resulting string will be `The value is 123!`.
+
+You can place `{value}` anywhere in the string and it will be substituted with the actual value.
+
+```yaml
+- transformer: strings.format
+  config:
+    # inField: <string> (Mandatory)
+    # Name of the field to convert
+    inField: field_name
+    # outField: <string> (Optional, default=same as inField)
+    # Name of the field where the output should be placed.
+    outField: field_name
+    # format_string: <string> (Optional, default="{value}")
+    # The format string where the value will be interpolated into.
+    format_string: "This is the value: {value}"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,8 @@ dependencies = [
   "cryptography",
 ]
 
+[project.optional-dependencies]
+xsl = ["lxml"]
+
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ alive-progress
 tabulate
 pymongo==4.10.1
 
+# subdependencies of pandas
+lxml
+
 # Below packages are subdependencies of sqlalchemy
 cryptography
 

--- a/src/beetl/beetl.py
+++ b/src/beetl/beetl.py
@@ -286,6 +286,15 @@ class Beetl:
                 continue
 
             self.benchmark("Starting database operations")
+            self.benchmark("Starting deletes")
+            amount["deletes"] = 0
+            if len(delete):
+                amount["deletes"] = sync.destination.delete(
+                    self.runTransformers(
+                        delete, sync.deletionTransformers, sync)
+                )
+
+            self.benchmark("Finished deletes, starting inserts")
             amount["inserts"] = 0
             if len(create):
                 amount["inserts"] = sync.destination.insert(
@@ -302,21 +311,14 @@ class Beetl:
                         update, sync.insertionTransformers, sync)
                 )
 
-            self.benchmark("Finished updates, starting deletes")
-            amount["deletes"] = 0
-            if len(delete):
-                amount["deletes"] = sync.destination.delete(
-                    self.runTransformers(
-                        delete, sync.deletionTransformers, sync)
-                )
-
-            self.benchmark("Finished deletes, sync finished")
+            self.benchmark("Finished updates, sync finished")
 
             print("Inserted: " + str(amount["inserts"]))
             print("Updated: " + str(amount["updates"]))
             print("Deleted: " + str(amount["deletes"]))
 
-            allAmounts.append([sync.name, *amount.values()])
+            allAmounts.append(
+                [sync.name, *[amount["inserts"], amount["updates"], amount["deletes"]]])
 
             sync.destination.disconnect()
 

--- a/src/beetl/comparison_result.py
+++ b/src/beetl/comparison_result.py
@@ -10,3 +10,9 @@ class ComparisonResult:
         self.create = create
         self.update = update
         self.delete = delete
+
+    def __str__(self):
+        return f"Create: {self.create.height}, Update: {self.update.height}, Delete: {self.delete.height}"
+
+    def __repr__(self):
+        return str(self)

--- a/src/beetl/sources/mongodb.py
+++ b/src/beetl/sources/mongodb.py
@@ -86,7 +86,7 @@ class MongodbSource(SourceInterface):
                 self.source_configuration.filter, projection=self.source_configuration.projection))
             if "_id" in polar.columns and polar["_id"].dtype == Object:
                 polar = polar.with_columns(
-                    polar["_id"].map_elements(lambda oid: str(oid)))
+                    polar["_id"].map_elements(lambda oid: str(oid), return_dtype=str))
             return polar
 
     def insert(self, data: DataFrame) -> int:

--- a/src/beetl/sources/mysql.py
+++ b/src/beetl/sources/mysql.py
@@ -134,7 +134,7 @@ class MysqlSource(SourceInterface):
     def update(self, data: pl.DataFrame):
         self._validate_unique_columns()
 
-        tempDB = self.source_configuration.table + "_udTemp"
+        tempDB = (self.source_configuration.table + "_udTemp").lower()
         try:
             with sqla.create_engine(
                 self.connection_settings.connection_string

--- a/src/beetl/sources/postgresql.py
+++ b/src/beetl/sources/postgresql.py
@@ -117,7 +117,7 @@ class PostgresqlSource(SourceInterface):
             self.source_configuration.table
             + "_udTemp_"
             + str(uuid.uuid4()).replace("-", "")
-        )
+        ).lower()
 
         try:
             with psycopg.connect(

--- a/src/beetl/sources/sqlserver.py
+++ b/src/beetl/sources/sqlserver.py
@@ -98,10 +98,16 @@ class SqlserverSource(SourceInterface):
             engine = sqla.create_engine(
                 self.connection_settings.connection_string)
         except ModuleNotFoundError:
-            engine = sqla.create_engine(
-                self.connection_settings.connection_string.replace(
-                    "mysql://", "mysql+pymysql://"
-                ))
+            try:
+                engine = sqla.create_engine(
+                    self.connection_settings.connection_string.replace(
+                        "mssql://", "mssql+pyodbc://"
+                    ))
+            except ModuleNotFoundError:
+                engine = sqla.create_engine(
+                    self.connection_settings.connection_string.replace(
+                        "mssql://", "mssql+pymssql://"
+                    ))
         self.connection = engine.connect()
 
     def _disconnect(self):
@@ -278,4 +284,4 @@ class SqlserverSource(SourceInterface):
             )
 
     def _get_temp_table_name(self, table_name: str):
-        return f"##{table_name}_{str(uuid4()).replace('-', '')}_temp"
+        return f"##{table_name}_{str(uuid4()).replace('-', '')}_temp".lower()

--- a/src/beetl/sources/xml.py
+++ b/src/beetl/sources/xml.py
@@ -1,0 +1,175 @@
+from typing import Literal, Tuple, Union
+import os
+import pandas as pd
+import polars as pl
+from .interface import (
+    register_source,
+    SourceInterface,
+    SourceInterfaceConfiguration,
+    SourceInterfaceConnectionSettings,
+)
+
+polar_to_xml_type_map = {
+    "Float32": "Float32",
+    "Float64": "Float64",
+    "Int8": "Int8",
+    "Int16": "Int16",
+    "Int32": "Int32",
+    "Int64": "Int64",
+    "Int128": "Int128",
+    "UInt8": "UInt8",
+    "UInt16": "UInt16",
+    "UInt32": "UInt32",
+    "UInt64": "UInt64",
+    "String": "str",
+    "str": "str",
+    "Utf8": "str",
+    "Boolean": "bool",
+}
+
+
+class XmlSyncConfiguration(SourceInterfaceConfiguration):
+    """The configuration class used for XML file sources"""
+
+    xpath: str = ""
+    unique_columns: Tuple[str] = ()
+    root_name: str = ""
+    row_name: str = ""
+    types: dict = None
+    xsl: Union[str, None] = None
+    parser: Literal["etree", "lxml"] = "etree"
+
+    def __init__(self, xpath: str = "./*", unique_columns: Tuple[str] = (), root_name: str = "root", row_name: str = "row", types: dict = None, xsl: str = None):
+        self.xpath = xpath
+        self.unique_columns = unique_columns
+        self.root_name = root_name
+        self.row_name = row_name
+
+        if xsl is not None:
+            self.xsl = xsl
+            self.parser = "lxml"
+
+        if types is not None:
+            for key, value in types.items():
+                if value not in polar_to_xml_type_map:
+                    raise ValueError(
+                        f"Type {value} is not supported for XML files")
+                types[key] = polar_to_xml_type_map[value]
+
+        self.types = types
+
+
+class XmlConnectionSettings(SourceInterfaceConnectionSettings):
+    """The connection configuration class used for XML file sources"""
+
+    path: str
+    encoding: str = "utf-8"
+
+    def __init__(self, path: str, encoding: str = "utf-8"):
+        self.path = path
+        self.encoding = encoding
+
+
+@register_source("xml", XmlSyncConfiguration, XmlConnectionSettings)
+class XmlSource(SourceInterface):
+    """ A source for reading and writing XML files """
+    ConnectionSettingsClass = XmlConnectionSettings
+    SourceConfigClass = XmlSyncConfiguration
+
+    connection_settings: XmlConnectionSettings = None
+    source_configuration: XmlSyncConfiguration = None
+    mutation_data: pl.DataFrame = pl.DataFrame()
+
+    def _configure(self):
+        pass
+
+    def _connect(self):
+        pass
+
+    def _disconnect(self):
+        """Flushes the mutated dataframe to the xml file"""
+        self.flush_data_to_file(self.mutation_data)
+
+    def _query(self, params=None) -> pl.DataFrame:
+        """Reads the XML file and returns a polars DataFrame"""
+
+        file_does_not_exist = not os.path.exists(self.connection_settings.path)
+        if file_does_not_exist:
+            return pl.DataFrame()
+
+        file_is_empty = os.path.getsize(self.connection_settings.path) == 0
+        if file_is_empty:
+            return pl.DataFrame()
+
+        data = pl.from_pandas(pd.read_xml(self.connection_settings.path,
+                              encoding=self.connection_settings.encoding, parser=self.source_configuration.parser, xpath=self.source_configuration.xpath, dtype=self.source_configuration.types, stylesheet=self.source_configuration.xsl))
+
+        return data
+
+    def insert(self, data: pl.DataFrame):
+        """Xml files are not yet supported as a destination"""
+        unique_columns = self.get_unique_columns()
+        destination = self.load_data_for_mutation(data)
+        updated = destination.update(
+            data, on=unique_columns, how="full", include_nulls=True)
+        self.save_data_after_mutation(updated)
+        return len(data)
+
+    def update(self, data: pl.DataFrame):
+        """Xml files are not yet supported as a destination"""
+        unique_columns = self.get_unique_columns()
+        destination = self.load_data_for_mutation(data)
+        updated = destination.update(
+            data, on=unique_columns, how="left", include_nulls=True)
+        self.save_data_after_mutation(updated)
+        return len(data)
+
+    def delete(self, data: pl.DataFrame):
+        """Xml files are not yet supported as a destination"""
+        unique_columns = self.get_unique_columns()
+        destination = self.load_data_for_mutation(data)
+        updated = destination.join(
+            data, on=unique_columns, how="anti")
+        self.save_data_after_mutation(updated)
+        return len(data)
+
+    def load_data_for_mutation(self, data_schema: pl.DataFrame) -> pl.DataFrame:
+        if self.mutation_data.height > 0:
+            return self.mutation_data
+
+        mutation_data = self._query()
+        self.mutation_data = self.append_missing_columns(
+            data_schema, mutation_data)
+
+        return self.mutation_data
+
+    def save_data_after_mutation(self, data: pl.DataFrame) -> None:
+        self.mutation_data = data
+
+    def flush_data_to_file(self, data: pl.DataFrame) -> None:
+        data_frame_is_missing_columns = data.width == 0
+        if data_frame_is_missing_columns:
+            return
+
+        if not os.path.exists(self.connection_settings.path):
+            with open(self.connection_settings.path, "w") as file:
+                file.flush()
+
+        data.to_pandas().to_xml(self.connection_settings.path,
+                                encoding=self.connection_settings.encoding, root_name=self.source_configuration.root_name, row_name=self.source_configuration.row_name, index=False, parser="etree")
+
+    def get_unique_columns(self):
+        if not self.source_configuration.unique_columns:
+            raise ValueError(
+                "Unique columns must be defined in the configuration when used as a destination")
+
+        return self.source_configuration.unique_columns
+
+    def append_missing_columns(self, source: pl.DataFrame, destination: pl.DataFrame) -> pl.DataFrame:
+        columns_to_append = [
+            column for column in source.columns if column not in destination.columns]
+        for column in columns_to_append:
+            destination = destination.with_columns(
+                pl.Series(column, [None] * destination.height, dtype=source[column].dtype))
+
+        return destination

--- a/src/beetl/transformers/frames.py
+++ b/src/beetl/transformers/frames.py
@@ -63,12 +63,19 @@ class FrameTransformer(TransformerInterface):
 
         Args:
             data (pl.DataFrame): The dataset
-            columns (List[dict]): A list of dicts (from: col1, to: col2)
+            columns (List[dict]): A list of dicts (from: col1, to: col2), or a dict (Dict[string, string]) {from_column: to_column}
+
 
         Returns:
             pl.DataFrame: DataFrame with renamed columns
         """
-        __class__._validate_fields(data.columns, columns)
+        columns_to_validate = []
+        if isinstance(columns, dict):
+            columns_to_validate = list(columns.keys())
+        else:
+            columns_to_validate = [x["from"] for x in columns]
+
+        __class__._validate_fields(data.columns, columns_to_validate)
         ncolumns = columns
 
         if isinstance(columns, dict):
@@ -97,7 +104,9 @@ class FrameTransformer(TransformerInterface):
         """
         __class__._validate_fields(data.columns, [x["from"] for x in columns])
         for column in columns:
-            data[column["to"]] = data[column["from"]]
+            fromField = column["from"]
+            toField = column["to"]
+            data = data.with_columns(data[fromField].alias(toField))
 
         return data
 

--- a/src/beetl/transformers/interface.py
+++ b/src/beetl/transformers/interface.py
@@ -30,12 +30,15 @@ class TransformerInterface:
         if isinstance(fields, str):
             fields = [fields]
 
-        if sum([1 for col in columns if col in fields]) == len(columns):
+        fields_not_in_columns = [
+            field for field in fields if field not in columns]
+        if any(fields_not_in_columns):
             raise KeyError(
-                f'Some of the field(s) {",".join(fields)} are not present '
+                f'Some of the field(s) {",".join(fields_not_in_columns)} are not present '
                 "in the dataset. Valid columns at this stage are:"
                 f'{",".join(columns)}'
             )
+
         return
 
 
@@ -51,7 +54,8 @@ class Transformers:
         namespace = namespace if namespace is not None else cls.__name__
         for fun in dir(cls):
             if not fun.startswith("_"):
-                Transformers._registerFunction(namespace, fun, getattr(cls, fun))
+                Transformers._registerFunction(
+                    namespace, fun, getattr(cls, fun))
 
     @staticmethod
     def runTransformer(transformer: str, data: POLARS_DF, **kwargs) -> POLARS_DF:

--- a/src/beetl/transformers/itop.py
+++ b/src/beetl/transformers/itop.py
@@ -28,7 +28,8 @@ class ItopTransformer(TransformerInterface):
             return concat_and_sha("-", toplevel, *st.values())
 
         new = data.with_columns(
-            pl.struct(inFields).map_elements(make_code).alias(outField)
+            pl.struct(inFields).map_elements(
+                make_code, return_dtype=str).alias(outField)
         )
 
         return new
@@ -132,6 +133,7 @@ class ItopTransformer(TransformerInterface):
                     f"Error: The source_comparison_field {source_comparison_field} is not present in DataFrame"
                 ) from e
             except KeyError as e:
-                raise Exception("Error: The key definition is not valid") from e
+                raise Exception(
+                    "Error: The key definition is not valid") from e
 
         return transformed

--- a/src/beetl/transformers/strings.py
+++ b/src/beetl/transformers/strings.py
@@ -274,6 +274,28 @@ class StringTransformer(TransformerInterface):
         """
 
         data = data.with_columns(
-            data[inField].map_elements(lambda oid: ObjectId(oid)))
+            data[inField].map_elements(lambda oid: ObjectId(oid), return_dtype=pl.Object))
 
+        return data
+
+    @staticmethod
+    def format(data: pl.DataFrame, inField: str, outField: str = "", format_string: str = "{value}"):
+        """
+        Formats the value in a string
+
+        Args:
+            data (pl.DataFrame): The dataFrame to modify
+            inField (str): The field to format
+            outField (str): The field to put the result in
+            format_string (str): The format string using {value} as the placeholder for the value. Defaults to "{value}". Example: "_{value}_.
+
+        Returns:
+            pl.DataFrame: The resulting DataFrame
+        """
+
+        if not outField:
+            outField = inField
+
+        data = data.with_columns(
+            data[inField].map_elements(lambda val: format_string.format(**{"value": val}), return_dtype=pl.Utf8).alias(outField))
         return data

--- a/tests/configurations/xml.py
+++ b/tests/configurations/xml.py
@@ -1,0 +1,58 @@
+def to_xml(source_file_path: str, destination_file_path: str) -> dict:
+    return {
+        "version": "V1",
+        "sources": [
+            {
+                "name": "src",
+                "type": "Xml",
+                "connection": {
+                    "path": source_file_path,
+                },
+            },
+            {
+                "name": "dst",
+                "type": "Xml",
+                "connection": {
+                    "path": destination_file_path,
+                },
+            },
+        ],
+        "sync": [
+            {
+                "source": "src",
+                "destination": "dst",
+                "sourceConfig": {
+                    "xpath": ".//PERSON",
+                    "types": {
+                        "Id": "Int64",
+                        "Name": "Utf8",
+                        "Age": "UInt8",
+                    }
+                },
+                "destinationConfig": {
+                    "xpath": ".//Person",
+                    "root_name": "PersonExport",
+                    "row_name": "Person",
+                    "unique_columns": ("Id")
+                },
+                "comparisonColumns": [
+                    {
+                        "name": "Id",
+                        "type": "Int64",
+                        "unique": True,
+                    },
+                    {
+                        "name": "Name",
+                        "type": "Utf8",
+                    },
+                    {
+                        "name": "Age",
+                        "type": "UInt8",
+                    },
+                ],
+                "sourceTransformers": [],
+                "destinationTransformers": [],
+                "insertionTransformers": [],
+            }
+        ],
+    }

--- a/tests/configurations/xml/nested-data.xml
+++ b/tests/configurations/xml/nested-data.xml
@@ -1,0 +1,20 @@
+<body>
+  <person>
+    <name>Sarah</name>
+    <address>
+      <street>1 main st</street>
+    </address>
+    <address>
+      <street>2 main st</street>
+    </address>
+  </person>
+  <person>
+    <name>Sophie</name>
+    <address>
+      <street>3 main st</street>
+    </address>
+    <address>
+      <street>4 main st</street>
+    </address>
+  </person>
+</body>

--- a/tests/configurations/xml/source-1.xml
+++ b/tests/configurations/xml/source-1.xml
@@ -1,0 +1,25 @@
+<PersonResponse>
+  <Body>
+    <PBSExportResponse>
+      <PBSExportResult>
+        <NewDataSet>
+          <PERSON>
+            <Id>1</Id>
+            <Name>John Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+          <PERSON>
+            <Id>10</Id>
+            <Name>Jimmy Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+          <PERSON>
+            <Id>11</Id>
+            <Name>Jimmy Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+        </NewDataSet>
+      </PBSExportResult>
+    </PBSExportResponse>
+  </Body>
+</PersonResponse>

--- a/tests/configurations/xml/source-2.xml
+++ b/tests/configurations/xml/source-2.xml
@@ -1,0 +1,25 @@
+<PersonResponse>
+  <Body>
+    <PBSExportResponse>
+      <PBSExportResult>
+        <NewDataSet>
+          <PERSON>
+            <Id>1</Id>
+            <Name>Jane Doe</Name>
+            <Age>55</Age>
+          </PERSON>
+          <PERSON>
+            <Id>10</Id>
+            <Name>Jimmy Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+          <PERSON>
+            <Id>11</Id>
+            <Name>Jimmy Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+        </NewDataSet>
+      </PBSExportResult>
+    </PBSExportResponse>
+  </Body>
+</PersonResponse>

--- a/tests/configurations/xml/source-3.xml
+++ b/tests/configurations/xml/source-3.xml
@@ -1,0 +1,25 @@
+<PersonResponse>
+  <Body>
+    <PBSExportResponse>
+      <PBSExportResult>
+        <NewDataSet>
+          <PERSON>
+            <Id>2</Id>
+            <Name>Phil Doe</Name>
+            <Age>27</Age>
+          </PERSON>
+          <PERSON>
+            <Id>10</Id>
+            <Name>Jimmy Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+          <PERSON>
+            <Id>11</Id>
+            <Name>Jimmy Doe</Name>
+            <Age>25</Age>
+          </PERSON>
+        </NewDataSet>
+      </PBSExportResult>
+    </PBSExportResponse>
+  </Body>
+</PersonResponse>

--- a/tests/integration_testing/beetl/sources/test_xml.py
+++ b/tests/integration_testing/beetl/sources/test_xml.py
@@ -1,0 +1,132 @@
+import unittest
+import os
+from src.beetl import beetl
+from tests.configurations.xml import to_xml
+from tests.helpers.manual_result import ManualResult
+
+
+class TestXmlSource(unittest.TestCase):
+    """Basic test of the xml source"""
+
+    def test_sync_between_two_xml_sources(self):
+        # Arrange
+        source_path = "tests/configurations/xml/source-1.xml"
+        destination_path = "tests/configurations/xml/destination.xml"
+
+        self.remove_if_exists(destination_path)
+
+        # Act
+        beetl_client = beetl.Beetl(beetl.BeetlConfig(
+            to_xml(source_path, destination_path)))
+        create_three_result = beetl_client.sync()
+
+        source_path = "tests/configurations/xml/source-2.xml"
+        beetl_client = beetl.Beetl(beetl.BeetlConfig(
+            to_xml(source_path, destination_path)))
+        update_one_result = beetl_client.sync()
+
+        source_path = "tests/configurations/xml/source-3.xml"
+        beetl_client = beetl.Beetl(beetl.BeetlConfig(
+            to_xml(source_path, destination_path)))
+        create_one_delete_one_result = beetl_client.sync()
+
+        # Assert
+        self.assertEqual(
+            create_three_result,
+            ManualResult(3, 0, 0)
+        )
+        self.assertEqual(
+            update_one_result,
+            ManualResult(0, 1, 0)
+        )
+        self.assertEqual(
+            create_one_delete_one_result,
+            ManualResult(1, 0, 1)
+        )
+
+        self.remove_if_exists(destination_path)
+
+    def remove_if_exists(self, path):
+        if os.path.exists(path):
+            os.remove(path)
+
+    def test_transforming_xml_using_xsl(self):
+        source_path = "tests/configurations/xml/nested-data.xml"
+        destination_path = "tests/configurations/xml/destination.xml"
+        self.remove_if_exists(destination_path)
+
+        # Transforms persons with addresses to addresses with person names
+        xsl = """<?xml version="1.0" encoding="UTF-8"?>
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:output method="xml" indent="yes"/>
+            <xsl:template match="//body">
+                <Output>
+                    <xsl:for-each select=".//person">
+                        <xsl:variable name="person_name" select=".//name"/>
+        
+                        <xsl:for-each select=".//address">
+                            <Record>
+                                <name><xsl:value-of select="$person_name"/></name>
+                                <street><xsl:value-of select=".//street"/></street>
+                            </Record>
+                        </xsl:for-each>
+                    </xsl:for-each>
+                </Output>
+            </xsl:template>
+        </xsl:stylesheet>"""
+
+        config = {
+            "version": "V1",
+            "sources": [
+                {
+                    "name": "src",
+                    "type": "Xml",
+                    "connection": {
+                        "path": source_path,
+                    },
+                },
+                {
+                    "name": "dst",
+                    "type": "Xml",
+                    "connection": {
+                        "path": destination_path,
+                    },
+                },
+            ],
+            "sync": [
+                {
+                    "source": "src",
+                    "destination": "dst",
+                    "sourceConfig": {
+                        "xsl": xsl
+                    },
+                    "destinationConfig": {
+                        "xpath": ".//address",
+                        "root_name": "addressexport",
+                        "row_name": "address",
+                        "unique_columns": ("name")
+                    },
+                    "comparisonColumns": [
+                        {
+                            "name": "name",
+                            "type": "Utf8",
+                            "unique": True
+                        },
+                    ],
+                    "sourceTransformers": [],
+                    "destinationTransformers": [],
+                    "insertionTransformers": [],
+                }
+            ]
+        }
+
+        beetl_client = beetl.Beetl(beetl.BeetlConfig(config))
+
+        result = beetl_client.sync(dry_run=True)[0].create
+
+        self.assertEqual(result.height, 4)
+        self.assertSequenceEqual(result.columns, ["name", "street"])
+        self.assertEqual(result.count()["name"][0], 4)
+        self.assertEqual(result.count()["street"][0], 4)
+
+        self.remove_if_exists(destination_path)

--- a/tests/unit_testing/transformers/test_strings.py
+++ b/tests/unit_testing/transformers/test_strings.py
@@ -1,0 +1,42 @@
+import unittest
+
+from polars import DataFrame, Series
+
+from src.beetl.transformers.strings import StringTransformer
+
+
+class UnitTestStringTransformers(unittest.TestCase):
+    def test_format__when_passed_format_string__string_is_formatted(self):
+        # arrange
+        inField = "field1"
+        outField = "field2"
+        format_string = "_{value}_goodbye"
+        expected = "_hello_goodbye"
+        data = DataFrame().with_columns(Series(inField, ["hello"]))
+        transformer = StringTransformer()
+
+        # act
+        result = transformer.format(
+            data, inField, outField, format_string)
+
+        # assert
+
+        resultingString = result[outField][0]
+        self.assertEqual(expected, resultingString)
+
+    def test_format__when_passed_no_format_string__string_is_formatted(self):
+        # arrange
+        inField = "field1"
+        outField = "field2"
+        expected = "hello"
+        data = DataFrame().with_columns(Series(inField, [expected]))
+        transformer = StringTransformer()
+
+        # act
+        result = transformer.format(
+            data, inField, outField)
+
+        # assert
+
+        resultingString = result[outField][0]
+        self.assertEqual(expected, resultingString)


### PR DESCRIPTION
### Changes ️️🔄️
- It is now possible to use Xml files as a data source and destination. Read more about it in the [docs](/sources/xml.html).
- The transformer [strings.format](/transformers/strings.html#Format) has been added, allowing values to be interpolated into string templates.
- `ComparisonResult` returned when running beetl in `dry-run` mode now has a __str__ and __repr__ implementation describing the changes in plane text, making them printable.

### Bugfixes 🐛
- Fixed a bug where the Sqlserver source incorrectly replaced the `mysql://` protocol part of the connection string instead of `mssql://`.
- Fixed a bug in the underlying column validation logic for transformers that raised an exception if the amount of columns to validate was the same as the total amount of columns on the dataframe.

### For developers 🧑‍💻
- Added new update diff tool in `compare.py` that can be used to figure out why a row needs updating. Read the docstring for the `diff_update` tool to understand how to use it. As of right now this is just an internal tool.