### PR TITLE
Removed check of fields that don't exist

### DIFF
--- a/docs/getting-started/change-notes.md
+++ b/docs/getting-started/change-notes.md
@@ -5,6 +5,9 @@
    - It is now forbidden to have extra parameters not part of the schema, validation errors will be raised if this happens.
 - Unused sqlserver source config parameters `query` and `table` have been removed.
 
+### Bugfixes 🐛
+- Fixed issue where `frames.extract_nested_rows` transformer failed due to it checking if fields exists before creating them.
+
 ## 1.0.4
 ### Changes ️️🔄️
 - It is now possible to use Xml files as a data source and destination. Read more about it in the [docs](/sources/xml.html).

--- a/src/beetl/transformers/frames.py
+++ b/src/beetl/transformers/frames.py
@@ -1,6 +1,8 @@
-from typing import List
 import json
+from typing import List
+
 import polars as pl
+
 from .interface import TransformerInterface, register_transformer_class
 
 
@@ -32,7 +34,13 @@ class FrameTransformer(TransformerInterface):
         return data
 
     @staticmethod
-    def conditional(data: pl.DataFrame, conditionField: str, ifTrue: str, ifFalse: str, targetField: str = ""):
+    def conditional(
+        data: pl.DataFrame,
+        conditionField: str,
+        ifTrue: str,
+        ifFalse: str,
+        targetField: str = "",
+    ):
         """Apply a conditional to a DataFrame
 
         Args:
@@ -51,8 +59,14 @@ class FrameTransformer(TransformerInterface):
         __class__._validate_fields(data.columns, [conditionField])
 
         data = data.with_columns(
-            pl.when(data[conditionField] == True).then(ifTrue).otherwise(ifFalse).alias(
-                targetField if targetField is not None and targetField != "" else conditionField)
+            pl.when(data[conditionField] == True)
+            .then(ifTrue)
+            .otherwise(ifFalse)
+            .alias(
+                targetField
+                if targetField is not None and targetField != ""
+                else conditionField
+            )
         )
 
         return data
@@ -81,10 +95,7 @@ class FrameTransformer(TransformerInterface):
         if isinstance(columns, dict):
             ncolumns = []
             for k, v in columns.items():
-                ncolumns.append({
-                    "from": k,
-                    "to": v
-                })
+                ncolumns.append({"from": k, "to": v})
 
         for column in ncolumns:
             data = data.rename({column["from"]: column["to"]})
@@ -152,10 +163,15 @@ class FrameTransformer(TransformerInterface):
         if columns is not None and len(columns) > 0:
             __class__._validate_fields(data.columns, columns)
 
-        return data.unique(subset=columns if columns is not None and len(columns) > 0 else None, maintain_order=True)
+        return data.unique(
+            subset=columns if columns is not None and len(columns) > 0 else None,
+            maintain_order=True,
+        )
 
     @staticmethod
-    def extract_nested_rows(data: pl.DataFrame, iterField: str = "", fieldMap: dict = {}, colMap: dict = {}):
+    def extract_nested_rows(
+        data: pl.DataFrame, iterField: str = "", fieldMap: dict = {}, colMap: dict = {}
+    ):
         """
         Convert each list item in a list column to a row
 
@@ -166,7 +182,6 @@ class FrameTransformer(TransformerInterface):
             column_path (str): The path in the list item to the value of the new column
             includeColumns (List[str]): Columns to include in the result
         """
-        __class__._validate_fields(data.columns, [x for x in colMap.keys()])
         new_obj = []
 
         def extract_field(data: dict, path: str):

--- a/tests/unit_testing/transformers/test_frames.py
+++ b/tests/unit_testing/transformers/test_frames.py
@@ -14,7 +14,6 @@ class UnitTestFramesTransformers(TestCase):
             [
                 {
                     "id": 1,
-                    "name": "A",
                     "items": [
                         {
                             "id": 3,
@@ -26,7 +25,6 @@ class UnitTestFramesTransformers(TestCase):
                 },
                 {
                     "id": 2,
-                    "name": "B",
                     "items": [
                         {
                             "id": 4,

--- a/tests/unit_testing/transformers/test_frames.py
+++ b/tests/unit_testing/transformers/test_frames.py
@@ -1,0 +1,62 @@
+import json
+from unittest import TestCase
+
+from polars import DataFrame
+
+from src.beetl.transformers.frames import FrameTransformer
+
+
+class UnitTestFramesTransformers(TestCase):
+    def test_extract_nested_rows__with_valid_input__nested_rows_are_extracted(
+        self,
+    ):
+        data = DataFrame(
+            [
+                {
+                    "id": 1,
+                    "name": "A",
+                    "items": [
+                        {
+                            "id": 3,
+                            "name": "a",
+                            "age": 30,
+                            "favorite_color": "blue",
+                        }
+                    ],
+                },
+                {
+                    "id": 2,
+                    "name": "B",
+                    "items": [
+                        {
+                            "id": 4,
+                            "name": "b",
+                            "age": 31,
+                            "favorite_color": "green",
+                        }
+                    ],
+                },
+            ]
+        )
+        config = {
+            "iterField": "items",
+            "fieldMap": {
+                "Name": "name",
+                "Age": "age",
+                "FavoriteColor": "favorite_color",
+            },
+            "colMap": {"Id": "id"},
+        }
+
+        result = FrameTransformer.extract_nested_rows(data, **config)
+
+        expected = DataFrame(
+            [
+                {"Name": "a", "Age": 30, "FavoriteColor": "blue", "Id": 1},
+                {"Name": "b", "Age": 31, "FavoriteColor": "green", "Id": 2},
+            ]
+        )
+
+        self.assertEquals(
+            json.dumps(result.to_dicts()), json.dumps(expected.to_dicts())
+        )


### PR DESCRIPTION
- Removed check in `frames.extract_nested_rows` that validated that fields exists before they have been created.